### PR TITLE
SockJS CDN will be retired, turn to use jsdelivr.

### DIFF
--- a/server/template-index.ejs
+++ b/server/template-index.ejs
@@ -10,7 +10,7 @@
     </head>
     <body>
         <div class="app" id="app"><%- app %></div>
-        <script src="//cdn.sockjs.org/sockjs-0.3.min.js"></script>
+        <script src="//cdn.jsdelivr.net/sockjs/0.3.4/sockjs.min.js"></script>
         <script src="/static/app.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Fix the warning in console:
```
*** SockJS CDN is being retired on Dec 1st *** Please transition to a public CDN.
See https://github.com/sockjs/sockjs-client/issues/198 for more information.
```