### PR TITLE
Bug fix: No title in detail panel when accessing from URL address

### DIFF
--- a/client/component-app.jsx
+++ b/client/component-app.jsx
@@ -38,10 +38,15 @@ module.exports = React.createClass({
         var detailsType = params.type.slice(0, -1);
 
         if (params.id) {
+            var title = this.props.state.details;
+            if (!title) {
+                title = params.type === "messages" ?
+                    JSON.parse(params.id)["message"] : params.id;
+            }
             return <Details
                 type={ detailsType }
                 id={ params.id }
-                title={ this.props.state.details || null }
+                title={ title }
                 onClose={ this._hideDetails } />;
         }
     },


### PR DESCRIPTION
For example, if we visit http://localhost:3000/browsers/IE%203.0/, it should display "IE 3.0" but now it displays "No title".