### PR TITLE
Don't display the first real-time update

### DIFF
--- a/client/component-report.jsx
+++ b/client/component-report.jsx
@@ -100,7 +100,7 @@ module.exports = React.createClass({
         Reports.fetch(props.type).done(this.updateData);
     },
     updateData: function() {
-        if (_.isEmpty(this.state.index)) {
+        if (this.state.index === null) {
             this.createIndex();
         } else {
             this.updateIndex();


### PR DESCRIPTION
fixes #25 

The problem is caused by creating index multiple times, which will fetch the data from the already changed Report. When the index first created, even if it was just `[]`, it shall not be created again. Instead, it should be updated.