### PR TITLE
fixed "npm WARN: No license field"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ErrorBoard",
   "version": "2.0.0",
+  "license": "MIT",
   "description": "Track and fix JavaScript errors fired by your visitor's browsers",
   "main": "eb.js",
   "author": {


### PR DESCRIPTION
The warning occurs every time when doing npm install